### PR TITLE
Get components by import instead of parsing the script

### DIFF
--- a/bin/analyze.py
+++ b/bin/analyze.py
@@ -4,6 +4,7 @@ from tools import producePlots, Process
 from pprint import pprint
 import ntpath
 import importlib
+import imp
 import yaml
 
 #__________________________________________________________
@@ -39,7 +40,7 @@ def main():
     analysisName = ops.analysis_name
 
     # heppy analysis configuration
-    heppyCfg = ops.heppy_cfg
+    heppyCfgPath = ops.heppy_cfg
 
     # process dictionary
     processDict = ops.proc_file_json
@@ -67,12 +68,8 @@ def main():
     MT = ops.MT
     
     # retrieve list of processes from heppy cfg
-    processes = []
-    with open(heppyCfg) as f:
-        lines = f.readlines()
-        for l in lines:
-            if 'splitFactor' in l:
-                processes.append(l.rsplit('.', 1)[0])
+    heppyCfg = imp.load_source('heppyCfg', heppyCfgPath)
+    processes = [c.name for c in heppyCfg.selectedComponents]
 
     with open(processDict) as f:
         procDict = json.load(f)


### PR DESCRIPTION
This imports the heppy cfg using `imp` and gets the component names from `selectedComponents` instead of parsing the files, looking for `<componentName>.splitFactor`


I may have missed something, but I think it is the same in all usecases - even if you want to use more components in the flattreeanalyzer, it's better to add another list, nobody expects the config to be parsed line by line!